### PR TITLE
Use pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ $ cd Reservoir
 
 # Install dependencies and setup database
 $ edgedb project init
-$ npm i
+$ pnpm i
 
 # Begin development server
-$ npm run dev
+$ pnpm dev
 ```
 
 You can learn more about developing Nuxt websites with their [guide](https://nuxt.com/docs/getting-started/introduction).
@@ -66,9 +66,9 @@ $ ./bins/xd.sh release
 > If you want to continue developing after building for production, you will need to do the following:
 >
 > ```shell
-> $ npm run clean
-> $ npm run dev:queryBuilder
-> $ npm run dev
+> $ pnpm clean
+> $ pnpm dev:queryBuilder
+> $ pnpm dev
 > ```
 >
 > This is due to incompatibilities with [EdgeDB's generator](https://www.edgedb.com/docs/clients/js/generation) using different JS flavors and build variants.

--- a/bins/xd.sh
+++ b/bins/xd.sh
@@ -35,8 +35,8 @@ Commands:
 
 x_release() {
     # Build production server
-    npm run clean
-    npm run build
+    pnpm run clean
+    pnpm run build
 
     # Copy over EdgeDB project and migrations
     cp edgedb.toml .output/edgedb.toml


### PR DESCRIPTION
[pnpm](https://pnpm.io/) is a faster and more efficient version of npm. I've started using it locally. This PR updates the README and `xd.sh` to use pnpm so as not to break my local configuration.

## Things to consider

Should I add a notice about using pnpm?